### PR TITLE
Enable fetching main subjects from sparql for all tasks

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -87,6 +87,7 @@ def match_main_subjects_from_sparql(args: argparse.Namespace = None,
     else:
         console.print("Got 0 results. Try another query or debug it using --debug")
 
+
 def export_jobs_to_quickstatements():
     logger = logging.getLogger(__name__)
     logger.info("Exporting jobs to QuickStatements V1 commands. One file for each job.")

--- a/src/helpers/jobs.py
+++ b/src/helpers/jobs.py
@@ -8,11 +8,12 @@ from typing import Union, List, TYPE_CHECKING
 from src import strip_prefix, print_best_practice, console, ask_yes_no_question, \
     TaskIds, print_found_items_table, ask_add_to_job_queue, print_keep_an_eye_on_wdqs_lag, print_running_jobs, \
     print_finished, print_job_statistics
+from src.helpers.menus import select_task
 from src.models.academic_journals import AcademicJournalItems
 from src.models.riksdagen_documents import RiksdagenDocumentItems
 from src.models.scholarly_articles import ScholarlyArticleItems
 from src.models.thesis import ThesisItems
-from src.tasks import tasks
+from src.tasks import tasks, Task
 
 if TYPE_CHECKING:
     from src import Task, BatchJob
@@ -138,9 +139,11 @@ def handle_job_preparation_or_run_directly_if_any_jobs(args: argparse.Namespace 
             run_jobs(jobs)
 
 
-def get_validated_main_subjects_as_jobs(args: argparse.Namespace = None,
-                                        main_subjects: List[str] = None,
-                                        jobs: List[BatchJob] = None):
+def get_validated_main_subjects_as_jobs(
+        args: argparse.Namespace = None,
+        main_subjects: List[str] = None,
+        jobs: List[BatchJob] = None
+) -> List[BatchJob]:
     """This function randomly picks a subject and present it for validation"""
     # logger = logging.getLogger(__name__)
     if jobs is None:
@@ -151,6 +154,11 @@ def get_validated_main_subjects_as_jobs(args: argparse.Namespace = None,
         raise ValueError("args was None")
     if main_subjects is None:
         raise ValueError("main subjects was None")
+    task: Task = select_task()
+    if task is None:
+        raise ValueError("Got no task")
+    if not isinstance(task, Task):
+        raise ValueError("task was not a Task object")
     # TODO implement better check for duplicates to avoid wasting resources
     picked_before = []
     while True:
@@ -159,7 +167,7 @@ def get_validated_main_subjects_as_jobs(args: argparse.Namespace = None,
         if qid not in picked_before:
             job = process_qid_into_job(qid=qid,
                                        # The scientific article task is hardcoded for now
-                                       task=tasks[0],
+                                       task=task,
                                        args=args,
                                        confirmation=args.no_confirmation)
             if job is not None:

--- a/src/helpers/menus.py
+++ b/src/helpers/menus.py
@@ -4,49 +4,8 @@ from typing import List
 from consolemenu import SelectionMenu
 
 from src.models.suggestion import Suggestion
-from src.models.wikidata import WikimediaLanguageCode, Item
-
-# def select_lexical_category():
-#     logger = logging.getLogger(__name__)
-#     menu = SelectionMenu(WikidataLexicalCategory.__members__.keys(), "Select a lexical category")
-#     menu.show()
-#     menu.join()
-#     selected_lexical_category_index = menu.selected_option
-#     category_mapping = {}
-#     for index, item in enumerate(WikidataLexicalCategory):
-#         category_mapping[index] = item
-#     selected_lexical_category = category_mapping[selected_lexical_category_index]
-#     logger.debug(f"selected:{selected_lexical_category_index}="
-#                  f"{selected_lexical_category}")
-#     return selected_lexical_category
-from src.tasks import tasks
-
-
-def select_language():
-    logger = logging.getLogger(__name__)
-    menu = SelectionMenu(WikimediaLanguageCode.__members__.keys(), "Select a language")
-    menu.show()
-    menu.join()
-    selected_language_index = menu.selected_option
-    mapping = {}
-    for index, item in enumerate(WikimediaLanguageCode):
-        mapping[index] = item
-    selected_language = mapping[selected_language_index]
-    logger.debug(f"selected:{selected_language_index}="
-                 f"{selected_language}")
-    return selected_language
-
-
-def select_task():
-    logger = logging.getLogger(__name__)
-    menu = SelectionMenu(tasks, "Select a task")
-    menu.show()
-    menu.join()
-    task_index = menu.selected_option
-    selected_task = tasks[task_index]
-    logger.debug(f"selected:{task_index}="
-                 f"{selected_task}")
-    return selected_task
+from src.models.wikidata import Item
+from src.tasks import tasks, Task
 
 
 def select_suggestion(suggestions: List[Suggestion] = None,
@@ -66,3 +25,44 @@ def select_suggestion(suggestions: List[Suggestion] = None,
         logger.debug(f"selected:{selected_index}="
                      f"{selected_suggestion}")
     return selected_suggestion
+
+
+def select_task() -> Task:
+    logger = logging.getLogger(__name__)
+    menu = SelectionMenu(tasks, "Select a task")
+    menu.show()
+    menu.join()
+    task_index = menu.selected_option
+    selected_task = tasks[task_index]
+    logger.debug(f"selected:{task_index}="
+                 f"{selected_task}")
+    return selected_task
+
+
+# def select_language():
+#     logger = logging.getLogger(__name__)
+#     menu = SelectionMenu(WikimediaLanguageCode.__members__.keys(), "Select a language")
+#     menu.show()
+#     menu.join()
+#     selected_language_index = menu.selected_option
+#     mapping = {}
+#     for index, item in enumerate(WikimediaLanguageCode):
+#         mapping[index] = item
+#     selected_language = mapping[selected_language_index]
+#     logger.debug(f"selected:{selected_language_index}="
+#                  f"{selected_language}")
+#     return selected_language
+
+# def select_lexical_category():
+#     logger = logging.getLogger(__name__)
+#     menu = SelectionMenu(WikidataLexicalCategory.__members__.keys(), "Select a lexical category")
+#     menu.show()
+#     menu.join()
+#     selected_lexical_category_index = menu.selected_option
+#     category_mapping = {}
+#     for index, item in enumerate(WikidataLexicalCategory):
+#         category_mapping[index] = item
+#     selected_lexical_category = category_mapping[selected_lexical_category_index]
+#     logger.debug(f"selected:{selected_lexical_category_index}="
+#                  f"{selected_lexical_category}")
+#     return selected_lexical_category

--- a/src/models/wikidata.py
+++ b/src/models/wikidata.py
@@ -805,7 +805,11 @@ class Item(Entity):
             if id is not None:
                 self.id = str(EntityID(id))
             if description is None and label is None and aliases is None:
-                logging.debug("here now")
+                logging.debug("No of description, label or aliases received")
+                if task is None:
+                    raise ValueError("Got no task")
+                if not isinstance(task, Task):
+                    raise ValueError("task was not a Task object")
                 self.fetch_label_and_description_and_aliases(task=task)
             elif label is None or aliases is None:
                 raise ValueError("This is not supported. "
@@ -847,6 +851,8 @@ class Item(Entity):
         """Fetch label and aliases in the task language from the Wikidata API"""
         if task is None:
             raise ValueError("task was None")
+        if not isinstance(task, Task):
+            raise ValueError("task was not a Task object")
         from src.helpers.console import console
         with console.status(f"Fetching {task.language_code.name.title()} label and aliases from the Wikidata API..."):
             wbi = WikibaseIntegrator()


### PR DESCRIPTION
This enables the user e.g. to improve the scientific journal items using this command that matches on all science subjects:
python itemsubjector.py --sparql "SELECT ?item WHERE {?item wdt:P31 wd:Q2465832. MINUS {?item wdt:P1889 [].}}"
